### PR TITLE
chore(readme): resize logo and move founded-by to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>

--- a/packages/cli_core/README.md
+++ b/packages/cli_core/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -9,6 +9,12 @@
     <a href="https://nonstopio.com">Website</a>
   </p>
 </p>
+
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
 
 # cli_core
 
@@ -177,9 +183,3 @@ We welcome contributions! Here's how you can help:
 ## 📜 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>

--- a/packages/connectivity_wrapper/README.md
+++ b/packages/connectivity_wrapper/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # connectivity_wrapper
 
@@ -364,11 +372,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/packages/dzod/README.md
+++ b/packages/dzod/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 <h1 align="center">🔐 Dzod</h1>
 
@@ -1100,11 +1108,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/packages/html_rich_text/README.md
+++ b/packages/html_rich_text/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # HTML Rich Text
 
@@ -247,11 +255,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/packages/morse_tap/README.md
+++ b/packages/morse_tap/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # morse_tap
 
@@ -286,11 +294,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/packages/nonstop_cli/README.md
+++ b/packages/nonstop_cli/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -8,6 +8,12 @@
     <a href="https://nonstopio.com/about-us">About</a> |
     <a href="https://nonstopio.com">Website</a>
   </p>
+
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
 
 <h1>🚀 NonStop CLI</h1>
 
@@ -316,9 +322,3 @@ nsio create my_app       # Alternative alias
 ## 📜 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>

--- a/packages/ns_firebase_utils/README.md
+++ b/packages/ns_firebase_utils/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # ns_firebase_utils
 
@@ -102,11 +110,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/packages/ns_intl_phone_input/README.md
+++ b/packages/ns_intl_phone_input/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Rajan Metaliya](https://github.com/rajan-nonstopio) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # Flutter Phone Validation Package by Nonstop IO
 
@@ -248,11 +256,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Rajan Metaliya](https://github.com/rajan-nonstopio) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/packages/ns_utils/README.md
+++ b/packages/ns_utils/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # ns_utils - Flutter Utility Library
 
@@ -156,11 +164,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/packages/timer_button/README.md
+++ b/packages/timer_button/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # Timer Button
 
@@ -141,11 +149,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>

--- a/plugins/contact_permission/README.md
+++ b/plugins/contact_permission/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -11,6 +11,14 @@
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # contact_permission
 
@@ -145,11 +153,3 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Ajay Kumar](https://github.com/ProjectAJ14) 🎉**
-
-</div>
-<!-- END:founded-by -->

--- a/tools/readme_sync/EXAMPLE_README.md
+++ b/tools/readme_sync/EXAMPLE_README.md
@@ -7,7 +7,7 @@ This is an example showing the correct placement of section markers in a package
 <!-- BEGIN:nonstop-header — auto-generated, do not edit. Run `melos sync:readme` to update -->
 <p align="center">
   <a href="https://nonstopio.com">
-    <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+    <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
   </a>
   <h1 align="center">NonStop</h1>
   <p align="center">Digital Product Development Experts for Startups & Enterprises</p>
@@ -17,6 +17,14 @@ This is an example showing the correct placement of section markers in a package
   </p>
 </p>
 <!-- END:nonstop-header -->
+
+<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
+<div align="center">
+
+> 🎉 [Founded by Your Name](https://github.com/yourusername) 🎉**
+
+</div>
+<!-- END:founded-by -->
 
 # example_package
 
@@ -136,14 +144,6 @@ A big thank you to all our contributors! 🙌
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 <!-- END:license -->
-
-<!-- BEGIN:founded-by — auto-generated, do not edit. Run `melos sync:readme` to update -->
-<div align="center">
-
-> 🎉 [Founded by Your Name](https://github.com/yourusername) 🎉**
-
-</div>
-<!-- END:founded-by -->
 
 ---
 

--- a/tools/readme_sync/config/packages.yaml
+++ b/tools/readme_sync/config/packages.yaml
@@ -10,6 +10,7 @@ packages:
     github_username: ProjectAJ14
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -17,7 +18,6 @@ packages:
       - connect
       - star-footer
       - license
-      - founded-by
 
   - name: dzod
     path: packages/dzod
@@ -27,6 +27,7 @@ packages:
     github_username: ProjectAJ14
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -34,7 +35,6 @@ packages:
       - connect
       - star-footer
       - license
-      - founded-by
 
   - name: timer_button
     path: packages/timer_button
@@ -44,6 +44,7 @@ packages:
     github_username: ProjectAJ14
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -51,7 +52,6 @@ packages:
       - connect
       - star-footer
       - license
-      - founded-by
 
   - name: ns_intl_phone_input
     path: packages/ns_intl_phone_input
@@ -61,6 +61,7 @@ packages:
     github_username: rajan-nonstopio
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -68,7 +69,6 @@ packages:
       - connect
       - star-footer
       - license
-      - founded-by
 
   - name: html_rich_text
     path: packages/html_rich_text
@@ -78,6 +78,7 @@ packages:
     github_username: ProjectAJ14
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -85,7 +86,6 @@ packages:
       - connect
       - star-footer
       - license
-      - founded-by
 
   - name: morse_tap
     path: packages/morse_tap
@@ -95,6 +95,7 @@ packages:
     github_username: ProjectAJ14
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -102,7 +103,6 @@ packages:
       - connect
       - star-footer
       - license
-      - founded-by
 
   - name: ns_utils
     path: packages/ns_utils
@@ -112,6 +112,7 @@ packages:
     github_username: ProjectAJ14
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -119,7 +120,6 @@ packages:
       - connect
       - star-footer
       - license
-      - founded-by
 
   - name: ns_firebase_utils
     path: packages/ns_firebase_utils
@@ -129,6 +129,7 @@ packages:
     github_username: ProjectAJ14
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -136,7 +137,6 @@ packages:
       - connect
       - star-footer
       - license
-      - founded-by
 
 plugins:
   - name: contact_permission
@@ -147,6 +147,7 @@ plugins:
     github_username: ProjectAJ14
     sections:
       - nonstop-header
+      - founded-by
       - badges
       - getting-started
       - import-package
@@ -154,4 +155,3 @@ plugins:
       - connect
       - star-footer
       - license
-      - founded-by

--- a/tools/readme_sync/templates/sections.yaml
+++ b/tools/readme_sync/templates/sections.yaml
@@ -7,7 +7,7 @@ sections:
     content: |
       <p align="center">
         <a href="https://nonstopio.com">
-          <img src="https://github.com/nonstopio.png" alt="Nonstop Logo" height="128" />
+          <img src="https://github.com/nonstopio.png?size=128" alt="Nonstop Logo" width="128" height="128" />
         </a>
         <h1 align="center">NonStop</h1>
         <p align="center">Digital Product Development Experts for Startups & Enterprises</p>


### PR DESCRIPTION
## Summary
- Add `?size=128` to the GitHub avatar URL in `tools/readme_sync/templates/sections.yaml` so pub.dev actually renders the logo at 128px (pub.dev's HTML sanitizer ignores `height` alone).
- Move the `founded-by` block from the bottom of every README to immediately below `nonstop-header`; update `tools/readme_sync/config/packages.yaml` section order to match.
- Apply the same moves to non-managed READMEs: `nonstop_cli`, `cli_core`, and `EXAMPLE_README.md`.

## Test plan
- [x] `melos sync:readme` → SUCCESS, no drift (idempotent re-run reports "No changes needed")
- [ ] Visual check on pub.dev once published: logo renders at 128px, Founded-by appears under About / Website
- [ ] GitHub rendering: confirm headers display correctly across all package READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)